### PR TITLE
Bump bs-moment to 0.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "1.3.0",
 			"license": "MIT",
 			"dependencies": {
-				"bs-moment": "^0.4.4",
+				"bs-moment": "^0.8.0",
 				"moment": "^2.24.0",
 				"react-dates": "^21.8.0"
 			},
@@ -89,11 +89,11 @@
 			"integrity": "sha512-Tfn5JSE7hrUlFcOoaLzVvkbgIemIorMIyoMr3TgvszWW7jFt2C9PdeMLtysYD9RU0MmU17b69+XJG1eRY2OBRg=="
 		},
 		"node_modules/bs-moment": {
-			"version": "0.4.4",
-			"resolved": "https://registry.npmjs.org/bs-moment/-/bs-moment-0.4.4.tgz",
-			"integrity": "sha512-fAcofbF1bTj6fuwk4cCZ0Teod75dhXPulnNhRwx7+PTtccNMdn35SCb98JxwrprQgCvoZircIgmu8nGLsOaqaA==",
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/bs-moment/-/bs-moment-0.8.0.tgz",
+			"integrity": "sha512-mBbPPpgabzOodLYCJjbva3GEVarngK/LU8Xm7Nlxqq4wdG2am467MMLoDuYtZXkTjmUohRRm4M07kU8ckhLj9A==",
 			"peerDependencies": {
-				"moment": "^2.24.0"
+				"moment": "^2.26.0"
 			}
 		},
 		"node_modules/bs-platform": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,44 @@
 {
 	"name": "@ahrefs/bs-react-dates",
 	"version": "1.3.0",
-	"lockfileVersion": 1,
+	"lockfileVersion": 3,
 	"requires": true,
-	"dependencies": {
-		"airbnb-prop-types": {
+	"packages": {
+		"": {
+			"name": "@ahrefs/bs-react-dates",
+			"version": "1.3.0",
+			"license": "MIT",
+			"dependencies": {
+				"bs-moment": "^0.4.4",
+				"moment": "^2.24.0",
+				"react-dates": "^21.8.0"
+			},
+			"devDependencies": {
+				"bs-platform": "^9.0.2"
+			},
+			"peerDependencies": {
+				"react": "^16.13.0 || ^17.0.0",
+				"react-dom": "^16.13.0 || ^17.0.0",
+				"reason-react": "^0.9.1"
+			}
+		},
+		"node_modules/@babel/runtime": {
+			"version": "7.21.5",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.5.tgz",
+			"integrity": "sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==",
+			"peer": true,
+			"dependencies": {
+				"regenerator-runtime": "^0.13.11"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/airbnb-prop-types": {
 			"version": "2.16.0",
 			"resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.16.0.tgz",
 			"integrity": "sha512-7WHOFolP/6cS96PhKNrslCLMYAI8yB1Pp6u6XmxozQOiZbsI5ycglZr5cHhBFfuRcQQjzCMith5ZPZdYiJCxUg==",
-			"requires": {
+			"dependencies": {
 				"array.prototype.find": "^2.1.1",
 				"function.prototype.name": "^1.1.2",
 				"is-regex": "^1.1.0",
@@ -19,98 +49,129 @@
 				"prop-types-exact": "^1.2.0",
 				"react-is": "^16.13.1"
 			},
-			"dependencies": {
-				"prop-types": {
-					"version": "15.7.2",
-					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-					"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-					"requires": {
-						"loose-envify": "^1.4.0",
-						"object-assign": "^4.1.1",
-						"react-is": "^16.8.1"
-					}
-				}
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			},
+			"peerDependencies": {
+				"react": "^0.14 || ^15.0.0 || ^16.0.0-alpha"
 			}
 		},
-		"array.prototype.find": {
+		"node_modules/array.prototype.find": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.1.tgz",
 			"integrity": "sha512-mi+MYNJYLTx2eNYy+Yh6raoQacCsNeeMUaspFPh9Y141lFSsWxxB8V9mM2ye+eqiRs917J6/pJ4M9ZPzenWckA==",
-			"requires": {
+			"dependencies": {
 				"define-properties": "^1.1.3",
 				"es-abstract": "^1.17.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"array.prototype.flat": {
+		"node_modules/array.prototype.flat": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz",
 			"integrity": "sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==",
-			"requires": {
+			"dependencies": {
 				"define-properties": "^1.1.3",
 				"es-abstract": "^1.17.0-next.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"brcast": {
+		"node_modules/brcast": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/brcast/-/brcast-2.0.2.tgz",
 			"integrity": "sha512-Tfn5JSE7hrUlFcOoaLzVvkbgIemIorMIyoMr3TgvszWW7jFt2C9PdeMLtysYD9RU0MmU17b69+XJG1eRY2OBRg=="
 		},
-		"bs-moment": {
+		"node_modules/bs-moment": {
 			"version": "0.4.4",
 			"resolved": "https://registry.npmjs.org/bs-moment/-/bs-moment-0.4.4.tgz",
-			"integrity": "sha512-fAcofbF1bTj6fuwk4cCZ0Teod75dhXPulnNhRwx7+PTtccNMdn35SCb98JxwrprQgCvoZircIgmu8nGLsOaqaA=="
+			"integrity": "sha512-fAcofbF1bTj6fuwk4cCZ0Teod75dhXPulnNhRwx7+PTtccNMdn35SCb98JxwrprQgCvoZircIgmu8nGLsOaqaA==",
+			"peerDependencies": {
+				"moment": "^2.24.0"
+			}
 		},
-		"bs-platform": {
+		"node_modules/bs-platform": {
 			"version": "9.0.2",
 			"resolved": "https://registry.npmjs.org/bs-platform/-/bs-platform-9.0.2.tgz",
 			"integrity": "sha512-Ye9JqJ4Oa7mcjjoOVRYI8Uc2Cf8N7jQLWDcdUplY7996d/YErSR7WitmV7XnSwr4EvdrbwjEsg1NxNjUQv3ChA==",
-			"dev": true
+			"hasInstallScript": true,
+			"bin": {
+				"bsb": "bsb",
+				"bsc": "bsc",
+				"bsrefmt": "bsrefmt",
+				"bstracing": "lib/bstracing"
+			}
 		},
-		"consolidated-events": {
+		"node_modules/consolidated-events": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/consolidated-events/-/consolidated-events-2.0.2.tgz",
 			"integrity": "sha512-2/uRVMdRypf5z/TW/ncD/66l75P5hH2vM/GR8Jf8HLc2xnfJtmina6F6du8+v4Z2vTrMo7jC+W1tmEEuuELgkQ=="
 		},
-		"deepmerge": {
+		"node_modules/deepmerge": {
 			"version": "1.5.2",
 			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-1.5.2.tgz",
-			"integrity": "sha512-95k0GDqvBjZavkuvzx/YqVLv/6YYa17fz6ILMSf7neqQITCPbnfEnQvEgMPNjH4kgobe7+WIL0yJEHku+H3qtQ=="
+			"integrity": "sha512-95k0GDqvBjZavkuvzx/YqVLv/6YYa17fz6ILMSf7neqQITCPbnfEnQvEgMPNjH4kgobe7+WIL0yJEHku+H3qtQ==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
-		"define-properties": {
+		"node_modules/define-properties": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
 			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-			"requires": {
+			"dependencies": {
 				"object-keys": "^1.0.12"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
-		"direction": {
+		"node_modules/direction": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/direction/-/direction-1.0.4.tgz",
-			"integrity": "sha512-GYqKi1aH7PJXxdhTeZBFrg8vUBeKXi+cNprXsC1kpJcbcVnV9wBsrOu1cQEdG0WeQwlfHiy3XvnKfIrJ2R0NzQ=="
+			"integrity": "sha512-GYqKi1aH7PJXxdhTeZBFrg8vUBeKXi+cNprXsC1kpJcbcVnV9wBsrOu1cQEdG0WeQwlfHiy3XvnKfIrJ2R0NzQ==",
+			"bin": {
+				"direction": "cli.js"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
 		},
-		"document.contains": {
+		"node_modules/document.contains": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/document.contains/-/document.contains-1.0.2.tgz",
 			"integrity": "sha512-YcvYFs15mX8m3AO1QNQy3BlIpSMfNRj3Ujk2BEJxsZG+HZf7/hZ6jr7mDpXrF8q+ff95Vef5yjhiZxm8CGJr6Q==",
-			"requires": {
+			"dependencies": {
 				"define-properties": "^1.1.3"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"enzyme-shallow-equal": {
+		"node_modules/enzyme-shallow-equal": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/enzyme-shallow-equal/-/enzyme-shallow-equal-1.0.4.tgz",
 			"integrity": "sha512-MttIwB8kKxypwHvRynuC3ahyNc+cFbR8mjVIltnmzQ0uKGqmsfO4bfBuLxb0beLNPhjblUEYvEbsg+VSygvF1Q==",
-			"requires": {
+			"dependencies": {
 				"has": "^1.0.3",
 				"object-is": "^1.1.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"es-abstract": {
+		"node_modules/es-abstract": {
 			"version": "1.17.6",
 			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
 			"integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
-			"requires": {
+			"dependencies": {
 				"es-to-primitive": "^1.2.1",
 				"function-bind": "^1.1.1",
 				"has": "^1.0.3",
@@ -122,215 +183,320 @@
 				"object.assign": "^4.1.0",
 				"string.prototype.trimend": "^1.0.1",
 				"string.prototype.trimstart": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"es-to-primitive": {
+		"node_modules/es-to-primitive": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
 			"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-			"requires": {
+			"dependencies": {
 				"is-callable": "^1.1.4",
 				"is-date-object": "^1.0.1",
 				"is-symbol": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"function-bind": {
+		"node_modules/function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
 			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
 		},
-		"function.prototype.name": {
+		"node_modules/function.prototype.name": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.2.tgz",
 			"integrity": "sha512-C8A+LlHBJjB2AdcRPorc5JvJ5VUoWlXdEHLOJdCI7kjHEtGTpHQUiqMvCIKUwIsGwZX2jZJy761AXsn356bJQg==",
-			"requires": {
+			"dependencies": {
 				"define-properties": "^1.1.3",
 				"es-abstract": "^1.17.0-next.1",
 				"functions-have-names": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"functions-have-names": {
+		"node_modules/functions-have-names": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.1.tgz",
-			"integrity": "sha512-j48B/ZI7VKs3sgeI2cZp7WXWmZXu7Iq5pl5/vptV5N2mq+DGFuS/ulaDjtaoLpYzuD6u8UgrUKHfgo7fDTSiBA=="
+			"integrity": "sha512-j48B/ZI7VKs3sgeI2cZp7WXWmZXu7Iq5pl5/vptV5N2mq+DGFuS/ulaDjtaoLpYzuD6u8UgrUKHfgo7fDTSiBA==",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
-		"global-cache": {
+		"node_modules/global-cache": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/global-cache/-/global-cache-1.2.1.tgz",
 			"integrity": "sha512-EOeUaup5DgWKlCMhA9YFqNRIlZwoxt731jCh47WBV9fQqHgXhr3Fa55hfgIUqilIcPsfdNKN7LHjrNY+Km40KA==",
-			"requires": {
+			"dependencies": {
 				"define-properties": "^1.1.2",
 				"is-symbol": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
-		"has": {
+		"node_modules/has": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
 			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"requires": {
+			"dependencies": {
 				"function-bind": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4.0"
 			}
 		},
-		"has-symbols": {
+		"node_modules/has-symbols": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
-		"hoist-non-react-statics": {
+		"node_modules/hoist-non-react-statics": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
 			"integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-			"requires": {
+			"dependencies": {
 				"react-is": "^16.7.0"
 			}
 		},
-		"is-callable": {
+		"node_modules/is-callable": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-			"integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw=="
+			"integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
-		"is-date-object": {
+		"node_modules/is-date-object": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-			"integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
+			"integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
-		"is-regex": {
+		"node_modules/is-regex": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
 			"integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
-			"requires": {
+			"dependencies": {
 				"has-symbols": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"is-symbol": {
+		"node_modules/is-symbol": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
 			"integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
-			"requires": {
+			"dependencies": {
 				"has-symbols": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"is-touch-device": {
+		"node_modules/is-touch-device": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-touch-device/-/is-touch-device-1.0.1.tgz",
 			"integrity": "sha512-LAYzo9kMT1b2p19L/1ATGt2XcSilnzNlyvq6c0pbPRVisLbAPpLqr53tIJS00kvrTkj0HtR8U7+u8X0yR8lPSw=="
 		},
-		"js-tokens": {
+		"node_modules/js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
-		"lodash": {
+		"node_modules/lodash": {
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 		},
-		"loose-envify": {
+		"node_modules/loose-envify": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
 			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-			"requires": {
+			"dependencies": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
+			},
+			"bin": {
+				"loose-envify": "cli.js"
 			}
 		},
-		"moment": {
+		"node_modules/moment": {
 			"version": "2.29.4",
 			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-			"integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
+			"integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+			"engines": {
+				"node": "*"
+			}
 		},
-		"object-assign": {
+		"node_modules/object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
-		"object-inspect": {
+		"node_modules/object-inspect": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
-			"integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA=="
+			"integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
-		"object-is": {
+		"node_modules/object-is": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
 			"integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
-			"requires": {
+			"dependencies": {
 				"define-properties": "^1.1.3",
 				"es-abstract": "^1.17.5"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"object-keys": {
+		"node_modules/object-keys": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+			"engines": {
+				"node": ">= 0.4"
+			}
 		},
-		"object.assign": {
+		"node_modules/object.assign": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
 			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
-			"requires": {
+			"dependencies": {
 				"define-properties": "^1.1.2",
 				"function-bind": "^1.1.1",
 				"has-symbols": "^1.0.0",
 				"object-keys": "^1.0.11"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
-		"object.entries": {
+		"node_modules/object.entries": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.2.tgz",
 			"integrity": "sha512-BQdB9qKmb/HyNdMNWVr7O3+z5MUIx3aiegEIJqjMBbBf0YT9RRxTJSim4mzFqtyr7PDAHigq0N9dO0m0tRakQA==",
-			"requires": {
+			"dependencies": {
 				"define-properties": "^1.1.3",
 				"es-abstract": "^1.17.5",
 				"has": "^1.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
-		"object.values": {
+		"node_modules/object.values": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
 			"integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
-			"requires": {
+			"dependencies": {
 				"define-properties": "^1.1.3",
 				"es-abstract": "^1.17.0-next.1",
 				"function-bind": "^1.1.1",
 				"has": "^1.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"performance-now": {
+		"node_modules/performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
 			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
 		},
-		"prop-types": {
-			"version": "15.6.2",
-			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
-			"integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
-			"requires": {
-				"loose-envify": "^1.3.1",
-				"object-assign": "^4.1.1"
+		"node_modules/prop-types": {
+			"version": "15.8.1",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+			"integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+			"dependencies": {
+				"loose-envify": "^1.4.0",
+				"object-assign": "^4.1.1",
+				"react-is": "^16.13.1"
 			}
 		},
-		"prop-types-exact": {
+		"node_modules/prop-types-exact": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/prop-types-exact/-/prop-types-exact-1.2.0.tgz",
 			"integrity": "sha512-K+Tk3Kd9V0odiXFP9fwDHUYRyvK3Nun3GVyPapSIs5OBkITAm15W0CPFD/YKTkMUAbc0b9CUwRQp2ybiBIq+eA==",
-			"requires": {
+			"dependencies": {
 				"has": "^1.0.3",
 				"object.assign": "^4.1.0",
 				"reflect.ownkeys": "^0.2.0"
 			}
 		},
-		"raf": {
+		"node_modules/raf": {
 			"version": "3.4.1",
 			"resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
 			"integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-			"requires": {
+			"dependencies": {
 				"performance-now": "^2.1.0"
 			}
 		},
-		"react-dates": {
+		"node_modules/react": {
+			"version": "16.14.0",
+			"resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+			"integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+			"peer": true,
+			"dependencies": {
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.2"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/react-dates": {
 			"version": "21.8.0",
 			"resolved": "https://registry.npmjs.org/react-dates/-/react-dates-21.8.0.tgz",
 			"integrity": "sha512-PPriGqi30CtzZmoHiGdhlA++YPYPYGCZrhydYmXXQ6RAvAsaONcPtYgXRTLozIOrsQ5mSo40+DiA5eOFHnZ6xw==",
-			"requires": {
+			"dependencies": {
 				"airbnb-prop-types": "^2.15.0",
 				"consolidated-events": "^1.1.1 || ^2.0.0",
 				"enzyme-shallow-equal": "^1.0.0",
@@ -347,69 +513,77 @@
 				"react-with-styles": "^4.1.0",
 				"react-with-styles-interface-css": "^6.0.0"
 			},
-			"dependencies": {
-				"prop-types": {
-					"version": "15.7.2",
-					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-					"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-					"requires": {
-						"loose-envify": "^1.4.0",
-						"object-assign": "^4.1.1",
-						"react-is": "^16.8.1"
-					}
-				}
+			"peerDependencies": {
+				"@babel/runtime": "^7.0.0",
+				"moment": "^2.18.1",
+				"react": "^0.14 || ^15.5.4 || ^16.1.1",
+				"react-dom": "^0.14 || ^15.5.4 || ^16.1.1",
+				"react-with-direction": "^1.3.1"
 			}
 		},
-		"react-is": {
+		"node_modules/react-dom": {
+			"version": "16.14.0",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+			"integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+			"peer": true,
+			"dependencies": {
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.2",
+				"scheduler": "^0.19.1"
+			},
+			"peerDependencies": {
+				"react": "^16.14.0"
+			}
+		},
+		"node_modules/react-is": {
 			"version": "16.13.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
 			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
 		},
-		"react-moment-proptypes": {
+		"node_modules/react-moment-proptypes": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/react-moment-proptypes/-/react-moment-proptypes-1.7.0.tgz",
 			"integrity": "sha512-ZbOn/P4u469WEGAw5hgkS/E+g1YZqdves2BjYsLluJobzUZCtManhjHiZKjniBVT7MSHM6D/iKtRVzlXVv3ikA==",
-			"requires": {
+			"dependencies": {
+				"moment": ">=1.6.0"
+			},
+			"peerDependencies": {
 				"moment": ">=1.6.0"
 			}
 		},
-		"react-outside-click-handler": {
+		"node_modules/react-outside-click-handler": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/react-outside-click-handler/-/react-outside-click-handler-1.3.0.tgz",
 			"integrity": "sha512-Te/7zFU0oHpAnctl//pP3hEAeobfeHMyygHB8MnjP6sX5OR8KHT1G3jmLsV3U9RnIYo+Yn+peJYWu+D5tUS8qQ==",
-			"requires": {
+			"dependencies": {
 				"airbnb-prop-types": "^2.15.0",
 				"consolidated-events": "^1.1.1 || ^2.0.0",
 				"document.contains": "^1.0.1",
 				"object.values": "^1.1.0",
 				"prop-types": "^15.7.2"
 			},
-			"dependencies": {
-				"prop-types": {
-					"version": "15.7.2",
-					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-					"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-					"requires": {
-						"loose-envify": "^1.4.0",
-						"object-assign": "^4.1.1",
-						"react-is": "^16.8.1"
-					}
-				}
+			"peerDependencies": {
+				"react": "^0.14 || >=15",
+				"react-dom": "^0.14 || >=15"
 			}
 		},
-		"react-portal": {
+		"node_modules/react-portal": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/react-portal/-/react-portal-4.2.1.tgz",
 			"integrity": "sha512-fE9kOBagwmTXZ3YGRYb4gcMy+kSA+yLO0xnPankjRlfBv4uCpFXqKPfkpsGQQR15wkZ9EssnvTOl1yMzbkxhPQ==",
-			"requires": {
+			"dependencies": {
 				"prop-types": "^15.5.8"
+			},
+			"peerDependencies": {
+				"react": "^15.0.0-0 || ^16.0.0-0 || ^17.0.0-0"
 			}
 		},
-		"react-with-direction": {
+		"node_modules/react-with-direction": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/react-with-direction/-/react-with-direction-1.3.1.tgz",
 			"integrity": "sha512-aGcM21ZzhqeXFvDCfPj0rVNYuaVXfTz5D3Rbn0QMz/unZe+CCiLHthrjQWO7s6qdfXORgYFtmS7OVsRgSk5LXQ==",
-			"requires": {
+			"dependencies": {
 				"airbnb-prop-types": "^2.10.0",
 				"brcast": "^2.0.2",
 				"deepmerge": "^1.5.2",
@@ -418,62 +592,96 @@
 				"object.assign": "^4.1.0",
 				"object.values": "^1.0.4",
 				"prop-types": "^15.6.2"
+			},
+			"peerDependencies": {
+				"react": "^0.14 || ^15 || ^16",
+				"react-dom": "^0.14 || ^15 || ^16"
 			}
 		},
-		"react-with-styles": {
+		"node_modules/react-with-styles": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/react-with-styles/-/react-with-styles-4.1.0.tgz",
 			"integrity": "sha512-zp05fyA6XFetqr07ox/a0bCFyEj//gUozI9cC1GW59zaGJ38STnxYvzotutgpzMyHOd7TFW9ZiZeBKjsYaS+RQ==",
-			"requires": {
+			"dependencies": {
 				"airbnb-prop-types": "^2.14.0",
 				"hoist-non-react-statics": "^3.2.1",
 				"object.assign": "^4.1.0",
 				"prop-types": "^15.7.2",
 				"react-with-direction": "^1.3.1"
 			},
-			"dependencies": {
-				"prop-types": {
-					"version": "15.7.2",
-					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-					"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-					"requires": {
-						"loose-envify": "^1.4.0",
-						"object-assign": "^4.1.1",
-						"react-is": "^16.8.1"
-					}
-				}
+			"peerDependencies": {
+				"@babel/runtime": "^7.0.0",
+				"react": ">=0.14",
+				"react-with-direction": "^1.3.1"
 			}
 		},
-		"react-with-styles-interface-css": {
+		"node_modules/react-with-styles-interface-css": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/react-with-styles-interface-css/-/react-with-styles-interface-css-6.0.0.tgz",
 			"integrity": "sha512-6khSG1Trf4L/uXOge/ZAlBnq2O2PEXlQEqAhCRbvzaQU4sksIkdwpCPEl6d+DtP3+IdhyffTWuHDO9lhe1iYvA==",
-			"requires": {
+			"dependencies": {
 				"array.prototype.flat": "^1.2.1",
 				"global-cache": "^1.2.1"
+			},
+			"peerDependencies": {
+				"@babel/runtime": "^7.0.0",
+				"react-with-styles": "^3.0.0 || ^4.0.0"
 			}
 		},
-		"reflect.ownkeys": {
+		"node_modules/reason-react": {
+			"version": "0.9.2",
+			"resolved": "https://registry.npmjs.org/reason-react/-/reason-react-0.9.2.tgz",
+			"integrity": "sha512-DzCeIBKZ/0RAK9dsHQx+gmpSEcHFKlJivl4UdFB8tirFg9Fb7MmtvUEBJX3IDhq5UVeoDHJV1NbQXM/SEQhpvA==",
+			"peer": true,
+			"peerDependencies": {
+				"bs-platform": "^7.1.1",
+				"react": "^16.8.1",
+				"react-dom": "^16.8.1"
+			}
+		},
+		"node_modules/reflect.ownkeys": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz",
 			"integrity": "sha1-dJrO7H8/34tj+SegSAnpDFwLNGA="
 		},
-		"string.prototype.trimend": {
+		"node_modules/regenerator-runtime": {
+			"version": "0.13.11",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+			"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+			"peer": true
+		},
+		"node_modules/scheduler": {
+			"version": "0.19.1",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+			"integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+			"peer": true,
+			"dependencies": {
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1"
+			}
+		},
+		"node_modules/string.prototype.trimend": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
 			"integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
-			"requires": {
+			"dependencies": {
 				"define-properties": "^1.1.3",
 				"es-abstract": "^1.17.5"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"string.prototype.trimstart": {
+		"node_modules/string.prototype.trimstart": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
 			"integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
-			"requires": {
+			"dependencies": {
 				"define-properties": "^1.1.3",
 				"es-abstract": "^1.17.5"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"bs:setup": "bsb -make-world"
 	},
 	"dependencies": {
-		"bs-moment": "^0.4.4",
+		"bs-moment": "^0.8.0",
 		"moment": "^2.24.0",
 		"react-dates": "^21.8.0"
 	},


### PR DESCRIPTION
The latest version of bs-moment includes values for the strings in `external`. This removes some warnings that might help with some ongoing changes in Melange (cc @anmonteiro).

Afaiu there are no breaking changes in bs-moment between these versions, everything seems to compile fine.

The first commit in the PR updates the lockfile to v3, the second commit shows the change in lockfile.